### PR TITLE
refactor(Makefile): update chainsaw setup and Helm targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,13 +369,14 @@ ifneq ($(strip $(HELM_DEPENDS)),)
 	done
 endif
 
-.PHONY: helm-install
-helm-install: helm-install-depends ## Install the helm chart.
-	$(HELM) upgrade --install --create-namespace --namespace $(TEST_NAMESPACE) --wait $(PROJECT_NAME) kubedoop/$(PROJECT_NAME) --version $(VERSION)
-
-.PHONY: helm-uninstall
-helm-uninstall: ## Uninstall the helm chart.
-	$(HELM) uninstall --namespace $(TEST_NAMESPACE) $(PROJECT_NAME)
+## helm uninstall depends
+.PHONY: helm-uninstall-depends
+helm-uninstall-depends: ## Uninstall the helm chart depends.
+ifneq ($(strip $(HELM_DEPENDS)),)
+	for dep in $(HELM_DEPENDS); do \
+		$(HELM) uninstall --namespace $(TEST_NAMESPACE) $$dep; \
+	done
+endif
 
 # kind
 KIND_VERSION ?= v0.24.0
@@ -448,7 +449,8 @@ $(CHAINSAW): $(LOCALBIN)
 chainsaw-setup: ## Run the chainsaw setup
 	make docker-build
 	$(KIND) --name $(KIND_CLUSTER_NAME) load docker-image $(IMG)
-	KUBECONFIG=$(KIND_KUBECONFIG) make helm-install
+	KUBECONFIG=$(KIND_KUBECONFIG) make helm-install-depends
+	KUBECONFIG=$(KIND_KUBECONFIG) make deploy
 
 .PHONY: chainsaw-test
 chainsaw-test: chainsaw ## Run the chainsaw test
@@ -456,4 +458,5 @@ chainsaw-test: chainsaw ## Run the chainsaw test
 
 .PHONY: chainsaw-cleanup
 chainsaw-cleanup: ## Run the chainsaw cleanup
-	KUBECONFIG=$(KIND_KUBECONFIG) make helm-uninstall
+	KUBECONFIG=$(KIND_KUBECONFIG) make helm-uninstall-depends
+	KUBECONFIG=$(KIND_KUBECONFIG) make undeploy

--- a/test/e2e/kerberos/chainsaw-test.yaml
+++ b/test/e2e/kerberos/chainsaw-test.yaml
@@ -123,6 +123,23 @@ spec:
     cleanup:
     - sleep:
         duration: 10s
+    catch:
+      - sleep:
+          duration: 5s
+      - script:
+          env:
+            - name: NAMESPACE
+              value: ($namespace)
+          content: |
+            set -ex
+            kubectl -n $NAMESPACE get pods
+      - describe:
+          apiVersion: v1
+          kind: Pod
+          selector: app.kubernetes.io/managed-by=hdfs-operator
+      - podLogs:
+          selector: app.kubernetes.io/managed-by=hdfs-operator
+          tail: -1
   - try:
     - apply:
         file: hbase.yaml

--- a/test/e2e/setup/hdfs-assert.yaml
+++ b/test/e2e/setup/hdfs-assert.yaml
@@ -31,5 +31,5 @@ kind: StatefulSet
 metadata:
   name: hdfs-default-datanode
 status:
-  availableReplicas: 2
-  replicas: 2
+  availableReplicas: 1
+  replicas: 1

--- a/test/e2e/setup/hdfs.yaml
+++ b/test/e2e/setup/hdfs.yaml
@@ -63,7 +63,7 @@ spec:
   dataNode:
     roleGroups:
       default:
-        replicas: 2
+        replicas: 1
         config:
           logging:
             datanode:

--- a/test/e2e/setup/zookeeper-assert.yaml
+++ b/test/e2e/setup/zookeeper-assert.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: zk-server-default
 status:
-  availableReplicas: 3
-  readyReplicas: 3
-  currentReplicas: 3
-  replicas: 3
+  availableReplicas: 1
+  readyReplicas: 1
+  currentReplicas: 1
+  replicas: 1

--- a/test/e2e/setup/zookeeper.yaml
+++ b/test/e2e/setup/zookeeper.yaml
@@ -14,7 +14,7 @@ spec:
   server:
     roleGroups:
       default:
-        replicas: 3
+        replicas: 1
         config:
           logging:
             zookeeperCluster:


### PR DESCRIPTION
Description:
This PR refactors the Helm targets and updates the chainsaw setup in the Makefile. The changes include:

- Removed helm-install and helm-uninstall targets.
- Updated chainsaw-setup target to use helm-install-depends instead of helm-install.

Purpose:
1. Refactor chainsaw test to rely on the helm-install-depends task for better modularity and dependency management.
2. Ensure the current operator uses the deploy task for deployment, aligning with the updated setup process.

These changes improve the modularity, clarity, and maintainability of the Makefile, making it easier to manage Helm dependencies and the chainsaw setup process.
