### PR TITLE
chore: upgrade golangci-lint to v2.12.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/internal/controller/authz/krb5.go
+++ b/internal/controller/authz/krb5.go
@@ -11,6 +11,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	securityEnabled    = "true"
+	rpcProtectionLevel = "privacy"
+)
+
 var (
 	TlsStorePassword = "changeit"
 
@@ -83,9 +88,9 @@ func (c *HbaseKerberosConfig) GetContainerEnvvars() []corev1.EnvVar {
 func (c *HbaseKerberosConfig) GetHbaseSite() map[string]string {
 	return map[string]string{
 		"hbase.security.authentication": AuthenticationType,
-		"hbase.security.authorization":  "true",
-		"hbase.rpc.protection":          "privacy",
-		"dfs.data.transfer.protection":  "privacy",
+		"hbase.security.authorization":  securityEnabled,
+		"hbase.rpc.protection":          rpcProtectionLevel,
+		"dfs.data.transfer.protection":  rpcProtectionLevel,
 		"hbase.rpc.engine":              "org.apache.hadoop.hbase.ipc.SecureRpcEngine",
 
 		"hbase.master.kerberos.principal":       c.getPrincipal("hbase"),
@@ -103,12 +108,12 @@ func (c *HbaseKerberosConfig) GetHbaseSite() map[string]string {
 		"hbase.rest.authentication.kerberos.principal": c.getPrincipal("HTTP"),
 		"hbase.rest.authentication.kerberos.keytab":    KetytabFile,
 
-		"hbase.ssl.enabled": "true",
+		"hbase.ssl.enabled": securityEnabled,
 		"hbase.http.policy": "HTTPS_ONLY",
 		// Recommended by the docs https://hbase.apache.org/book.html#hbase.ui.cache
-		"hbase.http.filter.no-store.enable": "true",
+		"hbase.http.filter.no-store.enable": securityEnabled,
 
-		"hbase.rest.ssl.enabled":           "true",
+		"hbase.rest.ssl.enabled":           securityEnabled,
 		"hbase.rest.ssl.keystore.store":    path.Join(TlsStoreDir, "keystore.p12"),
 		"hbase.rest.ssl.keystore.password": TlsStorePassword,
 		"hbase.rest.ssl.keystore.type":     "pkcs12",
@@ -118,8 +123,8 @@ func (c *HbaseKerberosConfig) GetHbaseSite() map[string]string {
 func (c *HbaseKerberosConfig) GetDiscoveryConfig() map[string]string {
 	return map[string]string{
 		"hbase.security.authentication":         AuthenticationType,
-		"hbase.rpc.protection":                  "privacy",
-		"hbase.ssl.enabled":                     "true",
+		"hbase.rpc.protection":                  rpcProtectionLevel,
+		"hbase.ssl.enabled":                     securityEnabled,
 		"hbase.maser.kerberos.principal":        c.getPrincipal("hbase"),
 		"hbase.regionserver.kerberos.principal": c.getPrincipal("hbase"),
 		"hbase.rest.kerberos.principal":         c.getPrincipal("hbase"),

--- a/internal/controller/common/statefulset.go
+++ b/internal/controller/common/statefulset.go
@@ -19,11 +19,16 @@ import (
 	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
 )
 
+const (
+	roleMaster       = "master"
+	roleRegionServer = "regionserver"
+)
+
 var (
 	roleNameToCommandArg = map[string]string{
-		"master":       "master",
-		"regionserver": "regionserver",
-		"restserver":   "rest",
+		roleMaster:       "master",
+		roleRegionServer: "regionserver",
+		"restserver":     "rest",
 	}
 	HBaseConfigDir      = path.Join(constants.KubedoopConfigDir)
 	HDFSConfigDir       = path.Join(constants.KubedoopConfigDir)
@@ -254,13 +259,13 @@ func (b *StatefulSetBuilder) getProbeHandler() *corev1.ProbeHandler {
 	// switch-cas
 	var prob *corev1.ProbeHandler
 	switch b.RoleName {
-	case "master":
+	case roleMaster:
 		prob = &corev1.ProbeHandler{
 			TCPSocket: &corev1.TCPSocketAction{
 				Port: intstr.FromString(b.RoleName),
 			},
 		}
-	case "regionserver":
+	case roleRegionServer:
 		prob = &corev1.ProbeHandler{
 			TCPSocket: &corev1.TCPSocketAction{
 				Port: intstr.FromString(b.RoleName),


### PR DESCRIPTION
Upgrade golangci-lint from v2.11.4 to v2.12.1.

## Remaining lint issues (goconst)

The new linter version introduces 4 \`goconst\` findings that cannot be auto-fixed:

- \`internal/controller/authz/krb5.go:86\` — string \`"true"\` has 5 occurrences
- \`internal/controller/authz/krb5.go:87\` — string \`"privacy"\` has 3 occurrences
- \`internal/controller/common/statefulset.go:24\` — string \`"master"\` has 3 occurrences
- \`internal/controller/common/statefulset.go:25\` — string \`"regionserver"\` has 3 occurrences

These should be addressed in a follow-up PR by extracting repeated strings into constants.