### PR TITLE
fix: use CR spec productVersion in GetImage instead of hardcoded default

### DIFF
--- a/internal/controller/cluster/cluster.go
+++ b/internal/controller/cluster/cluster.go
@@ -42,7 +42,12 @@ func (r *Reconciler) GetImage() *util.Image {
 	image := util.NewImage(
 		hbasev1alpha1.DefaultProductName,
 		version.BuildVersion,
-		hbasev1alpha1.DefaultProductVersion,
+		func() string {
+			if r.Spec.Image.ProductVersion != "" {
+				return r.Spec.Image.ProductVersion
+			}
+			return hbasev1alpha1.DefaultProductVersion
+		}(),
 		func(options *util.ImageOptions) {
 			options.Custom = r.Spec.Image.Custom
 			options.Repo = r.Spec.Image.Repo


### PR DESCRIPTION
Same fix as zookeeper-operator #348 and spark-k8s-operator #263.

GetImage() now prioritizes `Spec.Image.ProductVersion` from the CR, falling back to `DefaultProductVersion` only when not specified.