### PR TITLE
fix(e2e): replace bash-specific [[ with POSIX [ for /bin/sh compatibility

### DIFF
--- a/test/e2e/observability/chainsaw-test.yaml
+++ b/test/e2e/observability/chainsaw-test.yaml
@@ -100,7 +100,7 @@ spec:
 
                 # Test metrics endpoint accessibility
                 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT$ENDPOINT)
-                if [[ "$HTTP_CODE" != "200" ]]; then
+                if [ "$HTTP_CODE" != "200" ]; then
                   echo "ERROR: Failed to access metrics endpoint, HTTP code: $HTTP_CODE"
                   kill $PF_PID 2>/dev/null || true
                   exit 1


### PR DESCRIPTION
Replace `[[` with `[` in test/e2e/observability/chainsaw-test.yaml for POSIX sh compatibility (baseline checklist E).