### PR TITLE
fix(e2e): honor PRODUCT_VERSION in chainsaw values and test manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,3 @@ target
 
 # ignore any local file
 **/*local*
-
-# generated chainsaw values
-test/e2e/.values.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ target
 
 # ignore any local file
 **/*local*
+
+# generated chainsaw values
+test/e2e/.values.yaml

--- a/Makefile
+++ b/Makefile
@@ -299,13 +299,9 @@ helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 ##@ Chainsaw E2E
 
 CHAINSAW ?= $(LOCALBIN)/chainsaw
-CHAINSAW_VERSION ?= v0.2.13
+CHAINSAW_VERSION ?= v0.2.15
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
-# Chainsaw only resolves ($values.*) bindings from files passed via --values,
-# so the product version selected by the CI matrix must be written to a values
-# file before running the tests. See the chainsaw-values target.
-CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -351,13 +347,9 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
-.PHONY: chainsaw-values
-chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
-	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
-
 .PHONY: chainsaw-e2e
-chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
+chainsaw-e2e: ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup

--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,10 @@ CHAINSAW ?= $(LOCALBIN)/chainsaw
 CHAINSAW_VERSION ?= v0.2.13
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
+# Chainsaw only resolves ($values.*) bindings from files passed via --values,
+# so the product version selected by the CI matrix must be written to a values
+# file before running the tests. See the chainsaw-values target.
+CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -347,9 +351,13 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
+.PHONY: chainsaw-values
+chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
+	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
+
 .PHONY: chainsaw-e2e
-chainsaw-e2e: ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 ##@ Chainsaw E2E
 
 CHAINSAW ?= $(LOCALBIN)/chainsaw
-CHAINSAW_VERSION ?= v0.2.15
+CHAINSAW_VERSION ?= v0.2.14
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.

--- a/test/e2e/default/chainsaw-test.yaml
+++ b/test/e2e/default/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: default
 spec:
+  bindings:
+  - name: hbase_version
+    value: ($values.product_version)
   steps:
   - try:
     - apply:

--- a/test/e2e/default/hbase.yaml
+++ b/test/e2e/default/hbase.yaml
@@ -24,6 +24,8 @@ metadata:
     app.kubernetes.io/created-by: hbase-operator
   name: hbase
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig:
     zookeeperConfigMapName: hbase-znode
     hdfsConfigMapName: hdfs

--- a/test/e2e/kerberos/chainsaw-test.yaml
+++ b/test/e2e/kerberos/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kerberos
 spec:
   bindings:
+  - name: hbase_version
+    value: ($values.product_version)
   - name: relam
     value: KUBEDOOP.DEV   # kerberos relam, should be uppercase, see hdfs also
   - name: kadminPassword

--- a/test/e2e/kerberos/hbase.yaml
+++ b/test/e2e/kerberos/hbase.yaml
@@ -24,6 +24,8 @@ metadata:
     app.kubernetes.io/created-by: hbase-operator
   name: krb5-hbase
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig:
     zookeeperConfigMapName: krb5-hbase-znode
     hdfsConfigMapName: krb5-hdfs

--- a/test/e2e/observability/chainsaw-test.yaml
+++ b/test/e2e/observability/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: smoke-observability
 spec:
+  bindings:
+  - name: hbase_version
+    value: ($values.product_version)
   steps:
   # 1. Install ZooKeeper
   - name: install zookeeper

--- a/test/e2e/observability/hbase.yaml
+++ b/test/e2e/observability/hbase.yaml
@@ -12,6 +12,8 @@ kind: HbaseCluster
 metadata:
   name: test-hbase-observability
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig:
     zookeeperConfigMapName: hbase-observability-znode
     hdfsConfigMapName: hdfs

--- a/test/e2e/oidc/chainsaw-test.yaml
+++ b/test/e2e/oidc/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: oidc
 spec:
   bindings:
+  - name: hbase_version
+    value: ($values.product_version)
   - name: KEYCLOAK_REALM
     value: kubedoop
   - name: KEYCLOAK_CLIENT_ID

--- a/test/e2e/oidc/hbase.yaml
+++ b/test/e2e/oidc/hbase.yaml
@@ -24,6 +24,8 @@ metadata:
     app.kubernetes.io/created-by: hbase-operator
   name: hbase
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig:
     authentication:
       authenticationClass: oidc

--- a/test/e2e/pdb/chainsaw-test.yaml
+++ b/test/e2e/pdb/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: pdb
 spec:
+  bindings:
+  - name: hbase_version
+    value: ($values.product_version)
   steps:
   - try:
     - apply:

--- a/test/e2e/pdb/hbase.yaml
+++ b/test/e2e/pdb/hbase.yaml
@@ -24,6 +24,8 @@ metadata:
     app.kubernetes.io/created-by: hbase-operator
   name: hbase
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig:
     zookeeperConfigMapName: hbase-znode
     hdfsConfigMapName: hdfs


### PR DESCRIPTION
## Problem

The chainsaw e2e product-version matrix is dead, for two stacked reasons:

1. CI (`test.yml` / `release.yml`) sets a `PRODUCT_VERSION` env var per matrix leg, but chainsaw only populates `$values` from `--values` files and the `chainsaw-e2e` Makefile target never passed one — so `($values.product_version)` always resolved to `null`.
2. The e2e `HbaseCluster` manifests omitted `spec.image` entirely, so they never referenced `($values.product_version)` to begin with.

Net effect: both matrix legs (2.6.1, 2.6.2) tested the operator's `DefaultProductVersion` regardless of what CI requested. (A third link in the chain — `GetImage()` dropping `spec.image.productVersion` — was already fixed on main by #244.)

## Fix

- Add a `chainsaw-values` Makefile target that generates `test/e2e/.values.yaml` from `$PRODUCT_VERSION` (writes `product_version: null` when unset, preserving the default fallback for local runs), pass `--values` in `chainsaw-e2e`, and gitignore the generated file.
- Set `spec.image.productVersion: ($values.product_version)` in all five e2e `HbaseCluster` manifests, with an `hbase_version` binding per chainsaw-test.yaml (same pattern as zookeeper-operator). The zookeeper/hdfs dependency CRs keep their defaults.

## Verification

Verified live in a kind cluster before the rebase onto current main: ran the `default` suite with `PRODUCT_VERSION=2.6.2` (the non-default matrix leg) — the applied CR carried `productVersion: "2.6.2"` and the master/regionserver StatefulSets ran `quay.io/zncdatadev/hbase:2.6.2-kubedoop0.0.0-dev`, confirming the values → CR → StatefulSet image chain end to end; the suite passed. The CI matrix on this PR re-runs both legs on top of #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)