### PR TITLE
fix(e2e): pass the product version to chart-e2e, pin the linter version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,8 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so a new upstream release cannot break the
+          # pipeline without a code change. Keep in sync with the Makefile's
+          # GOLANGCI_LINT_VERSION.
+          version: v2.12.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  # Allow a manual run so the publish credentials can be verified on demand.
+  # Without this the only way to exercise them is to land a commit on main,
+  # which is how an expired HELM_CHARTS_REPO_TOKEN went unnoticed for weeks.
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so a new upstream release cannot break the
+          # pipeline without a code change. Keep in sync with the Makefile's
+          # GOLANGCI_LINT_VERSION.
+          version: v2.12.1
 
 
   golang-test:

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Ru
 	@echo "Installing hbase-operator chart..."
 	"$(HELM)" upgrade --install --create-namespace --namespace hbase-operator --kubeconfig $(CHAINSAW_KUBECONFIG) --wait hbase-operator ./target/charts/$(PROJECT_NAME)-$(VERSION).tgz
 	@echo "Running chainsaw e2e tests..."
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)
 
 .PHONY: helm-chart-publish ## Publish helm chart for the operator.
 helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
@@ -349,7 +349,7 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 
 .PHONY: chainsaw-e2e
 chainsaw-e2e: ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup

--- a/deploy/helm/hbase-operator/crds/crds.yaml
+++ b/deploy/helm/hbase-operator/crds/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: hbaseclusters.hbase.kubedoop.dev
 spec:
   group: hbase.kubedoop.dev


### PR DESCRIPTION
## Why

Part of the 0.4.0 release baseline alignment.

**chart-e2e ignored the product-version matrix.** `chainsaw-e2e` forwarded
`--set product_version`, but `chart-e2e` did not — so the chart-based run always
used the operator default no matter which version the CI matrix selected. The
matrix dimension was real for one job and decorative for the other, which is
worse than having no matrix: the job reports coverage it never had.

**golangci-lint was floating.** `golangci-lint-action` was invoked with no
`version:` input, so CI always installed the newest release. That breaks the
pipeline on an upstream release with no change here, and it diverges from the
v2.12.1 the Makefile already pinned.

**The chart CRDs had drifted** from `config/crd/bases`. `check-crds-sync` only
covers `config/`, so that copy can drift indefinitely without CI noticing.

**publish.yml could only be triggered by a push to main**, so its credentials
could not be verified on demand. That is how an expired `HELM_CHARTS_REPO_TOKEN`
went unnoticed for weeks.

## Verification

| Gate | Result |
|---|---|
| `make lint` (v2.12.1) | 0 issues |
| `make test` | all packages pass |
| `check-crds-sync` (simulated per the CI logic, clean tree) | passes |
| `make helm-crd-sync` | no drift after the regeneration commit |
| Workflow YAML syntax | valid; `workflow_dispatch` parses as expected |

The `--set` fix itself is exercised by this PR's own `chart-e2e` job, which is
the first run where the matrix value actually reaches the CR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)